### PR TITLE
fix radeon-profile-daemon download and amdgpu-fan build dependency

### DIFF
--- a/repos/xeals/pkgs/tools/misc/radeon-profile-daemon/default.nix
+++ b/repos/xeals/pkgs/tools/misc/radeon-profile-daemon/default.nix
@@ -9,7 +9,7 @@
 
 stdenv.mkDerivation rec {
   pname = "radeon-profile-daemon";
-  version = "20190603.g06qxq2h";
+  version = "20190603";
 
   buildInputs = [ qtbase ];
   nativeBuildInputs = [ qmake wrapQtAppsHook ];

--- a/repos/xeals/pkgs/unit/am/amdgpu-fan/package.nix
+++ b/repos/xeals/pkgs/unit/am/amdgpu-fan/package.nix
@@ -17,8 +17,9 @@ python3Packages.buildPythonApplication rec {
 
   propagatedBuildInputs = with python3Packages; [
     numpy
-    pyyaml
   ];
+
+  requirementsExtra = "pyyaml==5.4.1";
 
   patchPhase = ''
     substituteInPlace setup.py \


### PR DESCRIPTION
radeon-profile-daemon was generating an incorrect archive url to download.

amdgpu-fan will only build properly with pyyaml 5.4.1.  The latest pyyaml causes a build error.