### PR TITLE
Update NixOS Wiki link

### DIFF
--- a/repos/Nick1296/pkgs/vivado/2017.4.1.nix
+++ b/repos/Nick1296/pkgs/vivado/2017.4.1.nix
@@ -23,7 +23,7 @@ let
 
         Notice: given that this is a large (35.51GB) file, the usual methods of addings files
         to the Nix store (nix-store --add-fixed / nix-prefetch-url file:///) will likely not work.
-        Use the method described here: https://nixos.wiki/wiki/Cheatsheet#Adding_files_to_the_store
+        Use the method described here: https://wiki.nixos.org/wiki/Cheatsheet#Adding_files_to_the_store
       '';
     };
 
@@ -56,7 +56,7 @@ let
 
         Notice: given that this is a large (35.51GB) file, the usual methods of addings files
         to the Nix store (nix-store --add-fixed / nix-prefetch-url file:///) will likely not work.
-        Use the method described here: https://nixos.wiki/wiki/Cheatsheet#Adding_files_to_the_store
+        Use the method described here: https://wiki.nixos.org/wiki/Cheatsheet#Adding_files_to_the_store
       '';
     };
 

--- a/repos/Nick1296/pkgs/vivado/2017.4.nix
+++ b/repos/Nick1296/pkgs/vivado/2017.4.nix
@@ -18,7 +18,7 @@ let
 
         Notice: given that this is a large (35.51GB) file, the usual methods of addings files
         to the Nix store (nix-store --add-fixed / nix-prefetch-url file:///) will likely not work.
-        Use the method described here: https://nixos.wiki/wiki/Cheatsheet#Adding_files_to_the_store
+        Use the method described here: https://wiki.nixos.org/wiki/Cheatsheet#Adding_files_to_the_store
       '';
     };
 

--- a/repos/Nick1296/pkgs/vivado/2019.2.1-fhs.nix
+++ b/repos/Nick1296/pkgs/vivado/2019.2.1-fhs.nix
@@ -21,7 +21,7 @@ let
 
         Notice: given that this is a large (25.6GB) file, the usual methods of addings files
         to the Nix store (nix-store --add-fixed / nix-prefetch-url file:///) will likely not work.
-        Use the method described here: https://nixos.wiki/wiki/Cheatsheet#Adding_files_to_the_store
+        Use the method described here: https://wiki.nixos.org/wiki/Cheatsheet#Adding_files_to_the_store
       '';
     };
 
@@ -59,7 +59,7 @@ let
 
         Notice: given that this is a large (9GB) file, the usual methods of addings files
         to the Nix store (nix-store --add-fixed / nix-prefetch-url file:///) will likely not work.
-        Use the method described here: https://nixos.wiki/wiki/Cheatsheet#Adding_files_to_the_store
+        Use the method described here: https://wiki.nixos.org/wiki/Cheatsheet#Adding_files_to_the_store
       '';
     };
 

--- a/repos/Nick1296/pkgs/vivado/2019.2.1.nix
+++ b/repos/Nick1296/pkgs/vivado/2019.2.1.nix
@@ -46,7 +46,7 @@ let
 
         Notice: given that this is a large (25.6GB) file, the usual methods of addings files
         to the Nix store (nix-store --add-fixed / nix-prefetch-url file:///) will likely not work.
-        Use the method described here: https://nixos.wiki/wiki/Cheatsheet#Adding_files_to_the_store
+        Use the method described here: https://wiki.nixos.org/wiki/Cheatsheet#Adding_files_to_the_store
       '';
     };
 
@@ -84,7 +84,7 @@ let
 
          Notice: given that this is a large (9GB) file, the usual methods of addings files
          to the Nix store (nix-store --add-fixed / nix-prefetch-url file:///) will likely not work.
-         Use the method described here: https://nixos.wiki/wiki/Cheatsheet#Adding_files_to_the_store
+         Use the method described here: https://wiki.nixos.org/wiki/Cheatsheet#Adding_files_to_the_store
        '';
      };
 

--- a/repos/Nick1296/pkgs/vivado/2019.2.nix
+++ b/repos/Nick1296/pkgs/vivado/2019.2.nix
@@ -19,7 +19,7 @@ let
 
         Notice: given that this is a large (25.6GB) file, the usual methods of addings files
         to the Nix store (nix-store --add-fixed / nix-prefetch-url file:///) will likely not work.
-        Use the method described here: https://nixos.wiki/wiki/Cheatsheet#Adding_files_to_the_store
+        Use the method described here: https://wiki.nixos.org/wiki/Cheatsheet#Adding_files_to_the_store
       '';
     };
 

--- a/repos/angr/README.md
+++ b/repos/angr/README.md
@@ -10,7 +10,7 @@ Set of expressions to run [`angr`](https://angr.io) on Nix/NixOS.
 #### Pre-requisites
 
 Many packages in `angr`'s dependency tree are not available in past releases.
-In consequence, it is necessary to use the `unstable` channel ([more info about channels](https://nixos.wiki/wiki/Nix_channels#The_official_channels)).
+In consequence, it is necessary to use the `unstable` channel ([more info about channels](https://wiki.nixos.org/wiki/Nix_channels#The_official_channels)).
 
 Note that `unstable` may lag behind the `master` branch of NixOS/nixpkgs (see [status.nixos.org](https://status.nixos.org/));
 In that case, if you cannot wait for it, you can always use a local fork of `nixpkgs`...

--- a/repos/anthonyroussel/pkgs/shadow-client/README.md
+++ b/repos/anthonyroussel/pkgs/shadow-client/README.md
@@ -109,7 +109,7 @@ This package provides a standalone systemd daemon to start only the client wrapp
 
 ## 3. About VAAPI
 
-It is important to have `vaapi` enabled to make Shadow works correctly. You can find information on this [NixOS wiki page](https://nixos.wiki/wiki/Accelerated_Video_Playback).
+It is important to have `vaapi` enabled to make Shadow works correctly. You can find information on this [NixOS wiki page](https://wiki.nixos.org/wiki/Accelerated_Video_Playback).
 
 
 #### An example for Intel and AMD GPU

--- a/repos/colinsane/flake.nix
+++ b/repos/colinsane/flake.nix
@@ -10,7 +10,7 @@
 #
 #
 # DEVELOPMENT DOCS:
-# - Flake docs: <https://nixos.wiki/wiki/Flakes>
+# - Flake docs: <https://wiki.nixos.org/wiki/Flakes>
 # - Flake RFC: <https://github.com/tweag/rfcs/blob/flakes/rfcs/0049-flakes.md>
 #   - Discussion: <https://github.com/NixOS/rfcs/pull/49>
 # - <https://serokell.io/blog/practical-nix-flakes>

--- a/repos/colinsane/hosts/by-name/servo/fs.nix
+++ b/repos/colinsane/hosts/by-name/servo/fs.nix
@@ -1,5 +1,5 @@
 # zfs docs:
-# - <https://nixos.wiki/wiki/ZFS>
+# - <https://wiki.nixos.org/wiki/ZFS>
 # - <repo:nixos/nixpkgs:nixos/modules/tasks/filesystems/zfs.nix>
 #
 # zfs check health: `zpool status`

--- a/repos/colinsane/hosts/by-name/servo/net.nix
+++ b/repos/colinsane/hosts/by-name/servo/net.nix
@@ -39,7 +39,7 @@ in
     # '';
 
     # OVPN CONFIG (https://www.ovpn.com):
-    # DOCS: https://nixos.wiki/wiki/WireGuard
+    # DOCS: https://wiki.nixos.org/wiki/WireGuard
     # if you `systemctl restart wireguard-wg-ovpns`, make sure to also restart any other services in `NetworkNamespacePath = .../ovpns`.
     # TODO: why not create the namespace as a seperate operation (nix config for that?)
     networking.wireguard.enable = true;

--- a/repos/colinsane/hosts/by-name/servo/services/email/default.nix
+++ b/repos/colinsane/hosts/by-name/servo/services/email/default.nix
@@ -4,7 +4,7 @@
 #   - postfix / dovecot / rspamd / stalwart-jmap / sogo
 #
 # rspamd:
-# - nixos: <https://nixos.wiki/wiki/Rspamd>
+# - nixos: <https://wiki.nixos.org/wiki/Rspamd>
 # - guide: <https://rspamd.com/doc/quickstart.html>
 # - non-nixos example: <https://dataswamp.org/~solene/2021-07-13-smtpd-rspamd.html>
 #

--- a/repos/colinsane/hosts/by-name/servo/services/export/nfs.nix
+++ b/repos/colinsane/hosts/by-name/servo/services/export/nfs.nix
@@ -1,5 +1,5 @@
 # docs:
-# - <https://nixos.wiki/wiki/NFS>
+# - <https://wiki.nixos.org/wiki/NFS>
 # - <https://wiki.gentoo.org/wiki/Nfs-utils>
 # system files:
 # - /etc/exports

--- a/repos/colinsane/hosts/by-name/servo/services/matrix/default.nix
+++ b/repos/colinsane/hosts/by-name/servo/services/matrix/default.nix
@@ -1,4 +1,4 @@
-# docs: <https://nixos.wiki/wiki/Matrix>
+# docs: <https://wiki.nixos.org/wiki/Matrix>
 # docs: <https://nixos.org/manual/nixos/stable/index.html#module-services-matrix-synapse>
 # example config: <https://github.com/matrix-org/synapse/blob/develop/docs/sample_config.yaml>
 #

--- a/repos/colinsane/hosts/by-name/servo/services/nginx.nix
+++ b/repos/colinsane/hosts/by-name/servo/services/nginx.nix
@@ -1,4 +1,4 @@
-# docs: <https://nixos.wiki/wiki/Nginx>
+# docs: <https://wiki.nixos.org/wiki/Nginx>
 # docs: <https://nginx.org/en/docs/>
 { config, lib, pkgs, ... }:
 

--- a/repos/colinsane/hosts/by-name/servo/services/wikipedia.nix
+++ b/repos/colinsane/hosts/by-name/servo/services/wikipedia.nix
@@ -1,4 +1,4 @@
-# docs: <https://nixos.wiki/wiki/MediaWiki>
+# docs: <https://wiki.nixos.org/wiki/MediaWiki>
 { config, lib, ... }:
 
 # XXX: working to host wikipedia with kiwix instead of mediawiki

--- a/repos/colinsane/hosts/common/net/default.nix
+++ b/repos/colinsane/hosts/common/net/default.nix
@@ -30,7 +30,7 @@
   # see: <https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/issues/474>
   # iwd is an alternative that shouldn't have this problem
   # docs:
-  # - <https://nixos.wiki/wiki/Iwd>
+  # - <https://wiki.nixos.org/wiki/Iwd>
   # - <https://iwd.wiki.kernel.org/networkmanager>
   # - `man iwd.config`  for global config
   # - `man iwd.network` for per-SSID config

--- a/repos/colinsane/hosts/common/programs/msmtp.nix
+++ b/repos/colinsane/hosts/common/programs/msmtp.nix
@@ -1,4 +1,4 @@
-# docs: <https://nixos.wiki/wiki/Msmtp>
+# docs: <https://wiki.nixos.org/wiki/Msmtp>
 # validate with e.g.
 # - `echo -e "Content-Type: text/plain\r\nSubject: Test\r\n\r\nHello World" | sendmail test@uninsane.org`
 { config, lib, ... }:

--- a/repos/colinsane/hosts/common/programs/nautilus.nix
+++ b/repos/colinsane/hosts/common/programs/nautilus.nix
@@ -3,7 +3,7 @@
   sane.programs."gnome.nautilus" = {
     # some of its dbus services don't even refer to real paths
     packageUnwrapped = pkgs.rmDbusServicesInPlace (pkgs.gnome.nautilus.overrideAttrs (orig: {
-      # enable the "Audio and Video Properties" pane. see: <https://nixos.wiki/wiki/Nautilus>
+      # enable the "Audio and Video Properties" pane. see: <https://wiki.nixos.org/wiki/Nautilus>
       buildInputs = orig.buildInputs ++ (with pkgs.gst_all_1; [
         gst-plugins-good
         gst-plugins-bad

--- a/repos/colinsane/hosts/common/programs/neovim.nix
+++ b/repos/colinsane/hosts/common/programs/neovim.nix
@@ -10,7 +10,7 @@ let
       plugin = fzf-vim;
     }
     {
-      # treesitter syntax highlighting: https://nixos.wiki/wiki/Tree_sitters
+      # treesitter syntax highlighting: https://wiki.nixos.org/wiki/Tree_sitters
       # docs: https://github.com/nvim-treesitter/nvim-treesitter
       # config taken from: https://github.com/i077/system/blob/master/modules/home/neovim/default.nix
       # this is required for tree-sitter to even highlight

--- a/repos/colinsane/hosts/common/programs/rofi/snippets.txt
+++ b/repos/colinsane/hosts/common/programs/rofi/snippets.txt
@@ -1,6 +1,6 @@
 https://search.nixos.org/options?channel=unstable&query=
 https://search.nixos.org/packages?channel=unstable&query=
-https://nixos.wiki/index.php?go=Go&search=
+https://wiki.nixos.org/index.php?go=Go&search=
 https://nixos.org/manual/nix/stable/language/builtins.html
 https://github.com/nixos/nixpkgs/pulls?q=
 https://nur.nix-community.org/

--- a/repos/colinsane/hosts/common/programs/sway/default.nix
+++ b/repos/colinsane/hosts/common/programs/sway/default.nix
@@ -1,6 +1,6 @@
 { config, lib, pkgs, ... }:
 
-# docs: https://nixos.wiki/wiki/Sway
+# docs: https://wiki.nixos.org/wiki/Sway
 # sway-config docs: `man 5 sway`
 let
   cfg = config.sane.programs.sway;

--- a/repos/colinsane/hosts/common/systemd.nix
+++ b/repos/colinsane/hosts/common/systemd.nix
@@ -61,7 +61,7 @@ in
   };
 
   # allow ordinary users to `reboot` or `shutdown`.
-  # source: <https://nixos.wiki/wiki/Polkit>
+  # source: <https://wiki.nixos.org/wiki/Polkit>
   security.polkit.extraConfig = ''
     polkit.addRule(function(action, subject) {
       if (

--- a/repos/colinsane/hosts/modules/roles/build-machine.nix
+++ b/repos/colinsane/hosts/modules/roles/build-machine.nix
@@ -56,7 +56,7 @@ in
       # ];
 
       # granular compilation cache
-      # docs: <https://nixos.wiki/wiki/CCache>
+      # docs: <https://wiki.nixos.org/wiki/CCache>
       # investigate the cache with:
       # - `nix-ccache --show-stats`
       # - `build '.#ccache'

--- a/repos/colinsane/hosts/modules/wg-home.nix
+++ b/repos/colinsane/hosts/modules/wg-home.nix
@@ -1,6 +1,6 @@
 # wireguard VPN which allows my devices to talk to eachother even when on physically different LANs
 # for wireguard docs, see:
-# - <https://nixos.wiki/wiki/WireGuard>
+# - <https://wiki.nixos.org/wiki/WireGuard>
 # - <https://wiki.archlinux.org/title/WireGuard>
 { config, lib, pkgs, ... }:
 
@@ -109,7 +109,7 @@ in
         ;
       }
       (lib.mkIf cfg.forwardToWan {
-        # documented here: <https://nixos.wiki/wiki/WireGuard#Server_setup_2>
+        # documented here: <https://wiki.nixos.org/wiki/WireGuard#Server_setup_2>
         # TODO: don't hardcode eth0!
         postSetup = ''
           ${pkgs.iptables}/bin/iptables -t nat -A POSTROUTING -s ${cfg.ip}/24 -o eth0 -j MASQUERADE

--- a/repos/colinsane/modules/services/nixserve.nix
+++ b/repos/colinsane/modules/services/nixserve.nix
@@ -1,8 +1,8 @@
-# docs: <https://nixos.wiki/wiki/Binary_Cache>
+# docs: <https://wiki.nixos.org/wiki/Binary_Cache>
 # to copy something to this machine's nix cache, do:
 #   nix copy --to ssh://nixcache.uninsane.org PACKAGE
 #
-# docs: <https://nixos.wiki/wiki/Distributed_build>
+# docs: <https://wiki.nixos.org/wiki/Distributed_build>
 # to use this machine as a remote builder, just build anything with `-j0`.
 { config, lib, ... }:
 

--- a/repos/colinsane/modules/vpn.nix
+++ b/repos/colinsane/modules/vpn.nix
@@ -2,7 +2,7 @@
 # - `journalctl -u systemd-networkd`
 #
 # docs:
-# - wireguard (nixos): <https://nixos.wiki/wiki/WireGuard#Setting_up_WireGuard_with_systemd-networkd>
+# - wireguard (nixos): <https://wiki.nixos.org/wiki/WireGuard#Setting_up_WireGuard_with_systemd-networkd>
 # - wireguard (arch): <https://wiki.archlinux.org/title/WireGuard>
 #
 # to route all internet traffic through a VPN endpoint, run `systemctl start vpn-${vpnName}`

--- a/repos/colinsane/overlays/cross.nix
+++ b/repos/colinsane/overlays/cross.nix
@@ -85,7 +85,7 @@ let
     # documentation per config option is found with, for example:
     # - `fd Kconfig . | xargs rg 'config SUNRPC_DEBUG'`
     structuredExtraConfig = with lib.kernel; {
-      # recommended by: <https://nixos.wiki/wiki/Linux_kernel#Too_high_ram_usage>
+      # recommended by: <https://wiki.nixos.org/wiki/Linux_kernel#Too_high_ram_usage>
       DEBUG_INFO_BTF = lib.mkForce no;
 
       # other debug-related things i can probably disable

--- a/repos/colinsane/pkgs/additional/linux-megous/default.nix
+++ b/repos/colinsane/pkgs/additional/linux-megous/default.nix
@@ -59,7 +59,7 @@ let
     # see <repo:kernel.org/linux:Documentation/admin-guide/quickly-build-trimmed-linux.rst>
     DEBUG_KERNEL = lib.mkForce no;  # option group which seems to just gate the other DEBUG_ opts?
     DEBUG_INFO = lib.mkForce no;  # for gdb debugging
-    DEBUG_INFO_BTF = lib.mkForce no;  # BPF debug symbols. rec by <https://nixos.wiki/wiki/Linux_kernel#Too_high_ram_usage>
+    DEBUG_INFO_BTF = lib.mkForce no;  # BPF debug symbols. rec by <https://wiki.nixos.org/wiki/Linux_kernel#Too_high_ram_usage>
     # SCHED_DEBUG = lib.mkForce no;  # determines /sys/kernel/debug/sched
     # SUNRPC_DEBUG = lib.mkForce no;  # i use NFS though
 

--- a/repos/colinsane/pkgs/additional/sane-scripts/src/sane-reclaim-disk-space
+++ b/repos/colinsane/pkgs/additional/sane-scripts/src/sane-reclaim-disk-space
@@ -3,7 +3,7 @@
 
 # script to reclaim some hard drive space
 # some of this is documented here:
-# - <https://nixos.wiki/wiki/Storage_optimization>
+# - <https://wiki.nixos.org/wiki/Storage_optimization>
 
 set -xeu
 

--- a/repos/eownerdead/nixos/encrypted-dns.nix
+++ b/repos/eownerdead/nixos/encrypted-dns.nix
@@ -3,7 +3,7 @@ with lib; {
   options.eownerdead.encryptedDns = mkEnableOption (mdDoc ''
     Resolve domain name with encrypted DNS.
 
-    See the (wiki)[https://nixos.wiki/wiki/Encrypted_DNS].
+    See the (wiki)[https://wiki.nixos.org/wiki/Encrypted_DNS].
   '');
 
   config = mkIf config.eownerdead.encryptedDns {

--- a/repos/eownerdead/nixos/flatpak.nix
+++ b/repos/eownerdead/nixos/flatpak.nix
@@ -1,7 +1,7 @@
 { lib, pkgs, config, ... }:
 with lib; {
   options.eownerdead.flatpak = mkEnableOption (mdDoc ''
-    See the (wiki)[https://nixos.wiki/wiki/Flatpak]
+    See the (wiki)[https://wiki.nixos.org/wiki/Flatpak]
   '');
 
   config = mkIf config.eownerdead.flatpak {

--- a/repos/eownerdead/nixos/nix.nix
+++ b/repos/eownerdead/nixos/nix.nix
@@ -5,7 +5,7 @@ with lib; {
       options.eownerdead.flakes = mkEnableOption (mdDoc ''
         Enable unstable Nix flakes.
 
-        For See the (wiki)[https://nixos.wiki/wiki/Flakes].
+        For See the (wiki)[https://wiki.nixos.org/wiki/Flakes].
       '');
 
       config = (mkIf config.eownerdead.flakes {
@@ -35,7 +35,7 @@ with lib; {
       options.eownerdead.binaryCaches = mkEnableOption (mdDoc ''
         Add flequency used binary caches.
 
-        See the (wiki)[https://nixos.wiki/wiki/Binary_Cache]
+        See the (wiki)[https://wiki.nixos.org/wiki/Binary_Cache]
       '');
 
       config = (mkIf config.eownerdead.binaryCaches {

--- a/repos/eownerdead/nixos/sound.nix
+++ b/repos/eownerdead/nixos/sound.nix
@@ -1,7 +1,7 @@
 { lib, pkgs, config, ... }:
 with lib; {
   options.eownerdead.sound = mkEnableOption (mdDoc ''
-    See the (wiki)[https://nixos.wiki/wiki/PipeWire]
+    See the (wiki)[https://wiki.nixos.org/wiki/PipeWire]
   '');
 
   config = mkIf config.eownerdead.sound {

--- a/repos/instantos/utils/raspi4.nix
+++ b/repos/instantos/utils/raspi4.nix
@@ -2,7 +2,7 @@
 # used image: 
 #  - https://hydra.nixos.org/build/134720986/download/1/nixos-sd-image-21.03pre262561.581232454fd-aarch64-linux.img.zst
 #    from https://hydra.nixos.org/build/134720986, sha256sum: 2f756bc08a5f1e286a82ea4c9a50892f2aa9fd1688be37a85d4e36776569763e
-# see: https://nixos.wiki/wiki/NixOS_on_ARM/Raspberry_Pi_4
+# see: https://wiki.nixos.org/wiki/NixOS_on_ARM/Raspberry_Pi_4
 
 
 { config, pkgs, ... }:

--- a/repos/jbarthelmes/modules/steam.nix
+++ b/repos/jbarthelmes/modules/steam.nix
@@ -1,5 +1,5 @@
 {
-  # https://nixos.wiki/wiki/Steam
+  # https://wiki.nixos.org/wiki/Steam
   hardware = {
     opengl.driSupport32Bit = true;
     pulseaudio = {

--- a/repos/k0ral/hm-modules/essential/dev.cheat
+++ b/repos/k0ral/hm-modules/essential/dev.cheat
@@ -1,6 +1,6 @@
 % web, bookmark, documentation, reference, nix
 # NixOS wiki
-xdg-open https://nixos.wiki/
+xdg-open https://wiki.nixos.org/
 
 # nixpkgs manual
 xdg-open https://nixos.org/manual/nixpkgs

--- a/repos/kalbasit/pkgs/nixify/shell.nix
+++ b/repos/kalbasit/pkgs/nixify/shell.nix
@@ -1,6 +1,6 @@
 let
   # Look here for information about how to generate `nixpkgs-version.json`.
-  #  → https://nixos.wiki/wiki/FAQ/Pinning_Nixpkgs
+  #  → https://wiki.nixos.org/wiki/FAQ/Pinning_Nixpkgs
   pinnedVersion = builtins.fromJSON (builtins.readFile ./.nixpkgs-version.json);
   pinnedPkgs = import
     (builtins.fetchGit {

--- a/repos/kapack/README.md
+++ b/repos/kapack/README.md
@@ -62,7 +62,7 @@ kapack.pkgs.mkShell rec {
 If you want to pin the NUR-Kapack version you use, you can do one of the following.
 
 - Use a pinned tarball from GitHub such as `https://github.com/oar-team/nur-kapack/archive/2518733fefc28290ecffe44c3234eb2a36b731cd.tar.gz`
-- Use [Nix Flakes](https://nixos.wiki/wiki/Flakes)
+- Use [Nix Flakes](https://wiki.nixos.org/wiki/Flakes)
 
 Usage à la NUR
 --------------

--- a/repos/lschuermann/pkgs/vivado/vivado-2020_1.nix
+++ b/repos/lschuermann/pkgs/vivado/vivado-2020_1.nix
@@ -40,7 +40,7 @@ let
 
         Notice: given that this is a large (35.51GB) file, the usual methods of addings files
         to the Nix store (nix-store --add-fixed / nix-prefetch-url file:///) will likely not work.
-        Use the method described here: https://nixos.wiki/wiki/Cheatsheet#Adding_files_to_the_store
+        Use the method described here: https://wiki.nixos.org/wiki/Cheatsheet#Adding_files_to_the_store
       '';
     };
 

--- a/repos/lschuermann/pkgs/vivado/vivado-2022_2.nix
+++ b/repos/lschuermann/pkgs/vivado/vivado-2022_2.nix
@@ -44,7 +44,7 @@ let
 
         Notice: given that this is a large (35.51GB) file, the usual methods of addings files
         to the Nix store (nix-store --add-fixed / nix-prefetch-url file:///) will likely not work.
-        Use the method described here: https://nixos.wiki/wiki/Cheatsheet#Adding_files_to_the_store
+        Use the method described here: https://wiki.nixos.org/wiki/Cheatsheet#Adding_files_to_the_store
       '';
     };
 

--- a/repos/lucasew/bin/nvidia/offload
+++ b/repos/lucasew/bin/nvidia/offload
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# stolen from: https://nixos.wiki/wiki/Nvidia
+# stolen from: https://wiki.nixos.org/wiki/Nvidia
 #
 # You just need to wrap the program with this
 export __NV_PRIME_RENDER_OFFLOAD=1

--- a/repos/lucasew/nix/homes/main/qutebrowser.nix
+++ b/repos/lucasew/nix/homes/main/qutebrowser.nix
@@ -42,7 +42,7 @@ in
         a = "https://articleparser.vercel.app/api?url={}";
         w = "https://en.wikipedia.org/wiki/Special:Search?search={}&go=Go&ns0=1";
         aw = "https://wiki.archlinux.org/?search={}";
-        nw = "https://nixos.wiki/index.php?search={}";
+        nw = "https://wiki.nixos.org/index.php?search={}";
         g = "https://www.google.com/search?hl=en&q={}";
         ddg = "https://duckduckgo.com/?t=h_&q={}";
         nixpkgs = "https://github.com/search?q=repo%3ANixOS%2Fnixpkgs%20{}";

--- a/repos/lucasew/nix/nodes/common/lvm.nix
+++ b/repos/lucasew/nix/nodes/common/lvm.nix
@@ -4,7 +4,7 @@ let
   inherit (lib) mkIf;
 in
 
-# stolen from https://nixos.wiki/wiki/LVM
+# stolen from https://wiki.nixos.org/wiki/LVM
 
 {
   config = mkIf config.services.lvm.enable {

--- a/repos/mikilio/README.md
+++ b/repos/mikilio/README.md
@@ -8,7 +8,7 @@
 ## Setup
 
 Manuals and guides can be found at the [NUR](https://github.com/nix-community/NUR) repository.
-To use cached binaries with Cachix refer to [NixOS Wiki](https://nixos.wiki/wiki/Binary_Cache#Using_a_binary_cache).
+To use cached binaries with Cachix refer to [NixOS Wiki](https://wiki.nixos.org/wiki/Binary_Cache#Using_a_binary_cache).
 
 ## Packages
 

--- a/repos/milahu/pkgs/development/tools/js2nix/docs/comparison.md
+++ b/repos/milahu/pkgs/development/tools/js2nix/docs/comparison.md
@@ -2,7 +2,7 @@
 
 Most attempts to make Nix natively work with Node.js dependencies are built from the perspective of Nix, and only a couple work well. However, none are suitable for a large codebase such as Canva due to some architectural design decisions.
 
-The node2nix project is widely used and [is the recommended way](https://nixos.wiki/wiki/Language-specific_package_helpers#JavaScript_.2F_Node.js) for integrating node packages in nixpkgs. However, it doesn't address the issues above. For example, it only targets projects that expose CLIs. Also, it doesn't provide granularity in terms of the transitive dependencies, providing only a top-level package as a single derivation. This means it provides no granularity at the Nix derivation level. Only tarballs can be shared, but not the derivations. The local workflow and life-cycle scripting are also not addressed.
+The node2nix project is widely used and [is the recommended way](https://wiki.nixos.org/wiki/Language-specific_package_helpers#JavaScript_.2F_Node.js) for integrating node packages in nixpkgs. However, it doesn't address the issues above. For example, it only targets projects that expose CLIs. Also, it doesn't provide granularity in terms of the transitive dependencies, providing only a top-level package as a single derivation. This means it provides no granularity at the Nix derivation level. Only tarballs can be shared, but not the derivations. The local workflow and life-cycle scripting are also not addressed.
 
 The yarn2nix project solves some of the major issues by defining a Nix derivation per npm package, which provides granularity. However, it still has limitations (at the moment of writing, 9 Aug 2021):
 

--- a/repos/milahu/pkgs/development/tools/js2nix/docs/usage.md
+++ b/repos/milahu/pkgs/development/tools/js2nix/docs/usage.md
@@ -24,7 +24,7 @@ This Nix expression does the following:
 1. Build environment dependency closure as a Nix expression out of the `package.json` and `yarn.lock` files (see more about `buildEnv` function below).
 1. Return a Nix derivation that builds all top-level dependencies. That is, all the dependencies from the `dependencies` and `devDependencies` sections in the `./package.json` file.
 
-The approach above is [Import From Derivation](https://nixos.wiki/wiki/Import_From_Derivation) (IFD). While it's easy to use, it has some limitations that we may wish to avoid for advanced use cases. 
+The approach above is [Import From Derivation](https://wiki.nixos.org/wiki/Import_From_Derivation) (IFD). While it's easy to use, it has some limitations that we may wish to avoid for advanced use cases. 
 
 To avoid IFD, you can generate Nix expressions by using the js2nix executable (available from `js2nix.bin`):
 

--- a/repos/milahu/pkgs/development/tools/pandoc-bin/pandoc-bin.nix
+++ b/repos/milahu/pkgs/development/tools/pandoc-bin/pandoc-bin.nix
@@ -11,7 +11,7 @@ ideally, i want something automatic like npmlock2nix,
 to convert a lockfile to a nix expression.
 
 https://github.com/jgm/pandoc/releases
-https://nixos.wiki/wiki/Haskell
+https://wiki.nixos.org/wiki/Haskell
 https://haskell4nix.readthedocs.io/nixpkgs-developers-guide.html
 https://github.com/NixOS/nixpkgs/issues/221165 # Update request: pandoc 2.19.2 → 3.1.1
 */

--- a/repos/milahu/pkgs/spotify-adblock-linux/default.nix
+++ b/repos/milahu/pkgs/spotify-adblock-linux/default.nix
@@ -253,7 +253,7 @@ stdenv.mkDerivation rec {
   ];
 
   preBuild = ''
-    # https://nixos.wiki/wiki/C
+    # https://wiki.nixos.org/wiki/C
     NIX_CFLAGS_COMPILE="${debugFlags} $(pkg-config --cflags glib-2.0) $NIX_CFLAGS_COMPILE"
     NIX_LDFLAGS=" -L${spotify-unwrapped}/share/spotify $NIX_LDFLAGS" # libcef.so
     make clean # otherwise make says 'nothing to do'

--- a/repos/mipmip/home/pim/conf-desktop-linux/firefox.nix
+++ b/repos/mipmip/home/pim/conf-desktop-linux/firefox.nix
@@ -72,8 +72,8 @@
 #                            definedAliases = [ "@np" ];
 #                        };
 #                        "NixOS Wiki" = {
-#                            urls = [{ template = "https://nixos.wiki/index.php?search={searchTerms}"; }];
-#                            iconUpdateURL = "https://nixos.wiki/favicon.png";
+#                            urls = [{ template = "https://wiki.nixos.org/index.php?search={searchTerms}"; }];
+#                            iconUpdateURL = "https://wiki.nixos.org/favicon.png";
 #                            updateInterval = 24 * 60 * 60 * 1000;
 #                            definedAliases = [ "@nw" ];
 #                        };

--- a/repos/misterio/README.md
+++ b/repos/misterio/README.md
@@ -3,7 +3,7 @@
 
 # My NixOS configurations
 
-Here's my NixOS/home-manager config files. Requires [Nix flakes](https://nixos.wiki/wiki/Flakes).
+Here's my NixOS/home-manager config files. Requires [Nix flakes](https://wiki.nixos.org/wiki/Flakes).
 
 Looking for something simpler to start out with flakes? Try [my starter config repo](https://github.com/Misterio77/nix-starter-config).
 

--- a/repos/mloeper/pkgs/nodejs/default.nix
+++ b/repos/mloeper/pkgs/nodejs/default.nix
@@ -1,7 +1,7 @@
 { nodejs_20, fetchurl, ... }:
 
 # TODO(mloeper): this could fail due to patches not applying cleanly
-# we should probably use a different build mechanism, outlined here: https://nixos.wiki/wiki/Node.js#Example_nix_shell_for_Node.js_development
+# we should probably use a different build mechanism, outlined here: https://wiki.nixos.org/wiki/Node.js#Example_nix_shell_for_Node.js_development
 nodejs_20.overrideAttrs
   (upstream:
   let

--- a/repos/mloeper/pkgs/postman-cli/default.nix
+++ b/repos/mloeper/pkgs/postman-cli/default.nix
@@ -49,7 +49,7 @@ stdenvWithDebugSymbols.mkDerivation {
     runHook postInstall
   '';
 
-  # see: https://nixos.wiki/wiki/Packaging/Binaries
+  # see: https://wiki.nixos.org/wiki/Packaging/Binaries
   nativeBuildInputs = [
     # note: we use nix-alien instead since vercel does not support binary patching
     #autoPatchelfHook

--- a/repos/mozilla/README.rst
+++ b/repos/mozilla/README.rst
@@ -31,7 +31,7 @@ annoying pop-ups complaining about this.
 Note that all the ``-bin`` packages are "unfree" (because of the
 Firefox trademark, held by Mozilla), so you will need to set
 ``nixpkgs.config.allowUnfree`` in order to use them. More info `here
-<https://nixos.wiki/wiki/FAQ#How_can_I_install_a_proprietary_or_unfree_package.3F>`_.
+<https://wiki.nixos.org/wiki/FAQ#How_can_I_install_a_proprietary_or_unfree_package.3F>`_.
 
 Rust overlay
 ------------

--- a/repos/tinybeachthor/README.md
+++ b/repos/tinybeachthor/README.md
@@ -1,4 +1,4 @@
-**ARCHIVED - full on using [flakes](https://nixos.wiki/wiki/Flakes) now**
+**ARCHIVED - full on using [flakes](https://wiki.nixos.org/wiki/Flakes) now**
 
 # nur-packages
 

--- a/repos/twogn/README.md
+++ b/repos/twogn/README.md
@@ -23,7 +23,7 @@ For now, extension `cpp-tools` is only available for 64bit linux and platformio 
     extensions = with pkgs;[
       vscode-extensions.ms-vscode.cpptools
       nur.repos.twogn.vscode-extensions.platformio.platformio-ide
-      # for more informations about declaring vscode extensions, please check out the wiki written by nix community: https://nixos.wiki/wiki/Visual_Studio_Code
+      # for more informations about declaring vscode extensions, please check out the wiki written by nix community: https://wiki.nixos.org/wiki/Visual_Studio_Code
     ];
   };
 }

--- a/repos/vanilla/pkgs/arknights-mower/onnxruntime-py39.nix
+++ b/repos/vanilla/pkgs/arknights-mower/onnxruntime-py39.nix
@@ -22,7 +22,7 @@ python39Packages.buildPythonPackage rec {
       else "manylinux_2_17_x86_64.manylinux2014_x86_64";
   };
 
-  # https://nixos.wiki/wiki/Packaging/Python
+  # https://wiki.nixos.org/wiki/Packaging/Python
   propagatedBuildInputs = with python39Packages;
     [ protobuf flatbuffers numpy ];
 }

--- a/repos/vdemeester/README.md
+++ b/repos/vdemeester/README.md
@@ -52,7 +52,7 @@ soon-ish 👼):
 -   `lib`: shared code used during configuration (mostly `nix` code).
 -   `machines`: configuration per machines
 -   `modules`: holds nix modules (services, programs, hardware, profiles, …)
--   `overlays`: holds [nix overlays](https://nixos.wiki/wiki/Overlays)
+-   `overlays`: holds [nix overlays](https://wiki.nixos.org/wiki/Overlays)
 -   `pkgs`: holds nix packages (those should migrate under `overlays` or on `nur-packages`)
 -   `secrets`: holds non-shareable code, this folder is ignored and `make` commands will try
     to populate this. If it's empty, the rest of configuration is still meant to work but

--- a/repos/vdemeester/README.org
+++ b/repos/vdemeester/README.org
@@ -46,7 +46,7 @@ soon-ish 👼):
 - ~lib~: shared code used during configuration (mostly ~nix~ code).
 - ~machines~: configuration per machines
 - ~modules~: holds nix modules (services, programs, hardware, profiles, …)
-- ~overlays~: holds [[https://nixos.wiki/wiki/Overlays][nix overlays]]
+- ~overlays~: holds [[https://wiki.nixos.org/wiki/Overlays][nix overlays]]
 - ~pkgs~: holds nix packages (those should migrate under ~overlays~ or on ~nur-packages~)
 - ~secrets~: holds non-shareable code, this folder is ignored and =make= commands will try
   to populate this. If it's empty, the rest of configuration is still meant to work but

--- a/repos/vdemeester/hack/iso.nix
+++ b/repos/vdemeester/hack/iso.nix
@@ -23,7 +23,7 @@ let
 in
 {
   imports = [
-    # https://nixos.wiki/wiki/Creating_a_NixOS_live_CD
+    # https://wiki.nixos.org/wiki/Creating_a_NixOS_live_CD
     <nixpkgs/nixos/modules/installer/cd-dvd/installation-cd-minimal.nix>
     <nixpkgs/nixos/modules/installer/cd-dvd/channel.nix>
   ];

--- a/repos/wolfangaukang/docs/adding_overlays.md
+++ b/repos/wolfangaukang/docs/adding_overlays.md
@@ -1,7 +1,7 @@
 # How to add an overlay?
 
 **NOTE:** Use this guide as a reference:
-- [NixOS guide about overlays](https://nixos.wiki/wiki/Overlays)
+- [NixOS guide about overlays](https://wiki.nixos.org/wiki/Overlays)
 - [NixOS: The DOs and DON’Ts of nixpkgs overlays](https://blog.flyingcircus.io/2017/11/07/nixos-the-dos-and-donts-of-nixpkgs-overlays/) 
 
 To add an overlay:

--- a/repos/wolfangaukang/docs/impermanence.md
+++ b/repos/wolfangaukang/docs/impermanence.md
@@ -36,6 +36,6 @@ Follow the ZFS/BTRFS guide before going into this one. Also, read Graham Christe
 
 ## Sources
 - [The basic guide to all of the impermanence ideas on NixOS](https://grahamc.com/blog/erase-your-darlings)
-- [Official NixOS wiki regarding impermanence](https://nixos.wiki/wiki/Impermanence)
+- [Official NixOS wiki regarding impermanence](https://wiki.nixos.org/wiki/Impermanence)
 - [Guide to implementing it on NixOS the common way, with some examples](https://elis.nu/blog/2020/05/nixos-tmpfs-as-root/)
 - [Part 2 of the guide above, now with the impermanence module](https://elis.nu/blog/2020/06/nixos-tmpfs-as-home/)

--- a/repos/xddxdd/pkgs/uncategorized/vivado-2022_2/default.nix
+++ b/repos/xddxdd/pkgs/uncategorized/vivado-2022_2/default.nix
@@ -44,7 +44,7 @@ let
 
         Notice: given that this is a large (35.51GB) file, the usual methods of addings files
         to the Nix store (nix-store --add-fixed / nix-prefetch-url file:///) will likely not work.
-        Use the method described here: https://nixos.wiki/wiki/Cheatsheet#Adding_files_to_the_store
+        Use the method described here: https://wiki.nixos.org/wiki/Cheatsheet#Adding_files_to_the_store
       '';
     };
 


### PR DESCRIPTION
Hello there 👋!

The NixOS wiki is in the process of migrating from https://nixos.wiki to https://wiki.nixos.org.
You can find more information about it [here](https://github.com/NixOS/foundation/issues/113).

You seem to be using the old link in your repository, which is why we send you this PR.
If you feel like this is not correct or have any questions, feel free to [get in touch with us](https://github.com/NixOS/nixos-wiki-infra/issues/105).


Have a great day,

-- The NixOS Wiki-Team ❄️