### PR TITLE
cura5: fix run

### DIFF
--- a/repos/xeals/pkgs/by-name/cu/cura5/package.nix
+++ b/repos/xeals/pkgs/by-name/cu/cura5/package.nix
@@ -33,7 +33,7 @@ let
       fi
       args+=("$a")
     done
-    exec "${cura5}/bin/${name}" "''${args[@]}"
+    exec "${cura5}/bin/${pname}" "''${args[@]}"
   '';
 in
 stdenv.mkDerivation rec {


### PR DESCRIPTION
The cura5 package got mentioned in https://github.com/NixOS/nixpkgs/issues/186570#issuecomment-2523971943 by @FliegendeWurst, but NixOS couldn't find the binary when running `cura5`.

My commit fixed that issue for me.